### PR TITLE
v1.2.0: XML output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # scanc
+
 ![Test Status](https://github.com/mqxym/scanc/actions/workflows/python-publish.yml/badge.svg)
 
-> A fast, pure‑Python project code‑scanner that outputs clean, AI‑ready Markdown.
-> scanc stands for scanc(ode)
+> scanc = scan c(ode) <br>
+> A fast, pure‑Python project code‑scanner that outputs clean, AI‑ready Markdown or XML.
 
 `scanc` helps you **spill an entire codebase into an LLM prompt** (or a file) in seconds—while keeping noise low, controlling token budgets, and giving you full visibility.
 
@@ -36,11 +37,12 @@ pip install scanc[tiktoken]  # installs optional token‑counter support
 Scan a directory and emit Markdown:
 
 ```bash
-scanc .                     # scan current folder
-scanc -e py,js --tree       # only .py and .js files + directory tree
-scanc -e py -x "tests" | less # only py files exclude tests in path
-scanc --tokens gpt-4o  # show token count for gpt 4o only
-scanc -e py | pbcopy # scan and copy (macOS copy example)
+scanc .                         # scan current folder
+scanc -e py,js --tree           # only .py and .js files + directory tree
+scanc -f xml                    # output scan in xml format (new in v1.2.0)
+scanc -e py -x "tests" | less   # only py files exclude tests in path
+scanc --tokens gpt-4o           # show token count for gpt 4o only
+scanc -e py | pbcopy            # scan and copy (macOS copy command example)
 ```
 
 Write output directly to a file:

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ README = (HERE / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="scanc",
-    version="1.1.0",
-    description="AI-ready code-base scanner that outputs Markdown.",
+    version="1.2.0",
+    description="AI-ready code-base scanner that outputs Markdown or XML.",
     long_description=README,
     long_description_content_type="text/markdown",
     author="mqxym",

--- a/src/scanc/cli.py
+++ b/src/scanc/cli.py
@@ -9,7 +9,7 @@ import click
 
 from . import __version__
 from .core import DEFAULT_EXCLUDES, scan_directory
-from .formatter import format_result, MARKDOWN
+from .formatter import format_result, MARKDOWN, XML
 
 # --------------------------------------------------------------------------- #
 # Helpers
@@ -95,7 +95,7 @@ def _comma_separated(ctx, param, value):  # click callback
     "-f",
     "--format",
     "format_name",
-    type=click.Choice(["markdown"], case_sensitive=False),
+    type=click.Choice(["markdown", "xml"], case_sensitive=False),
     default="markdown",
     show_default=True,
     help="Output format.  Additional formats can be added via entry-points.",
@@ -136,7 +136,7 @@ def main(
         paths = [Path.cwd()]
     # --------------------------------------------------------------------- #
     # Collect files
-    files, tree_md = scan_directory(
+    files, tree_str = scan_directory(
         paths=paths,
         extensions=extensions,
         include_regex=include_regex,
@@ -157,8 +157,8 @@ def main(
 
     formatted = format_result(
         files=files,
-        tree_md=tree_md if tree else None,
-        formatter=MARKDOWN,
+        tree=tree_str if tree_str else None,
+        format_name=format_name,
     )
 
     try:

--- a/src/scanc/core.py
+++ b/src/scanc/core.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List, Sequence, Tuple
 
-from .tree import build_markdown_tree
+from .tree import build_tree
 
 # --------------------------------------------------------------------------- #
 # Defaults
@@ -180,5 +180,5 @@ def scan_directory(
             relative = path.relative_to(common_root) if path.is_absolute() else path
             files.append(ScannedFile(path=relative, language=lang or "text", content=text))
 
-    tree_md = build_markdown_tree(paths, files) if include_tree else None
-    return files, tree_md
+    tree_str = build_tree(paths, files) if include_tree else None
+    return files, tree_str

--- a/src/scanc/formatter.py
+++ b/src/scanc/formatter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from typing import Callable, List, Protocol
+from pathlib import Path
+from xml.sax.saxutils import escape
 
 from .core import ScannedFile
 
@@ -18,11 +20,15 @@ class Formatter(Protocol):
 # --------------------------------------------------------------------------- #
 
 
-def _markdown(files: List[ScannedFile], tree_md: str | None) -> str:
+def _markdown(files: List[ScannedFile], tree: str | None) -> str:
+    
+    def tree_md (tree_str: str) -> str:
+        return f"**File Structure**\n\n```text\n{tree_str}\n```\n"
+    
     blocks: list[str] = []
     blocks.append("---\n\n## Codebase Scan\n\n")
-    if tree_md:
-        blocks.append(tree_md.rstrip() + "\n")
+    if tree:
+        blocks.append(tree_md(tree).rstrip() + "\n")
     for f in files:
         blocks.append(f"**{f.path}**\n\n```{f.language}\n{f.content}\n```\n")
     return "\n".join(blocks)
@@ -30,11 +36,58 @@ def _markdown(files: List[ScannedFile], tree_md: str | None) -> str:
 
 MARKDOWN: Formatter = _markdown
 
+# --------------------------------------------------------------------------- #
+# XML formatter
+# --------------------------------------------------------------------------- #
+
+
+def _xml(files: List[ScannedFile], tree: str | None) -> str:
+    
+    parts: list[str] = []
+    parts.append("<scan>")
+
+    if tree:
+        parts.append("<tree><![CDATA[\n" + tree.strip() + "\n]]></tree>")
+
+    for f in files:
+        ext = Path(f.path).suffix.lstrip(".") or (f.language or "")
+        path_attr = escape(str(f.path), {'"': "&quot;"})
+        lang_attr = escape(str(ext), {'"': "&quot;"})
+
+        parts.append(
+            f'<file path="{path_attr}">'
+            f'<code language="{lang_attr}"><![CDATA[\n{f.content}\n]]></code>'
+            f"</file>"
+        )
+
+    parts.append("</scan>")
+    return "\n".join(parts)
+
+
+XML: Formatter = _xml
 
 # --------------------------------------------------------------------------- #
 # Extensibility hook
 # --------------------------------------------------------------------------- #
 
+FORMATTERS: dict[str, Formatter] = {
+    "markdown": MARKDOWN,
+    "xml": XML,
+}
 
-def format_result(files: List[ScannedFile], tree_md: str | None, formatter: Formatter) -> str:
-    return formatter(files, tree_md)
+
+# --------------------------------------------------------------------------- #
+# Format dispatcher
+# --------------------------------------------------------------------------- #
+
+def format_result(
+    files: List[ScannedFile],
+    tree: str | None,
+    format_name: str,
+) -> str:
+    """Format scan results using the given format name."""
+    try:
+        formatter = FORMATTERS[format_name.lower()]
+    except KeyError:
+        raise ValueError(f"Unknown format: {format_name}")
+    return formatter(files, tree)

--- a/src/scanc/tree.py
+++ b/src/scanc/tree.py
@@ -36,7 +36,7 @@ def _to_tree(paths: Iterable[Path]) -> str:
     return "\n".join(tree_lines)
 
 
-def build_markdown_tree(scan_roots: Iterable[Path], files: List[ScannedFile]) -> str:
+def build_tree(scan_roots: Iterable[Path], files: List[ScannedFile]) -> str:
     """
     Return a fenced Markdown code-block containing the directory tree,
     respecting what was actually scanned.
@@ -46,4 +46,4 @@ def build_markdown_tree(scan_roots: Iterable[Path], files: List[ScannedFile]) ->
         if r.is_file():
             all_paths.append(Path(r.name))
     tree_str = _to_tree(all_paths)
-    return f"**File Structure**\n\n```text\n{tree_str}\n```\n"
+    return tree_str

--- a/tests/test_private_helpers.py
+++ b/tests/test_private_helpers.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from scanc.tree import build_markdown_tree
+from scanc.tree import build_tree
 from scanc.core import ScannedFile
 
 
@@ -8,5 +8,5 @@ def test_build_markdown_tree_single_file(tmp_path: Path):
     p = tmp_path / "x.txt"
     p.write_text("x")
     files = [ScannedFile(path=p.relative_to(tmp_path), language="text", content="x")]
-    md = build_markdown_tree([p], files)
+    md = build_tree([p], files)
     assert "└── x.txt" in md

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -5,6 +5,6 @@ from scanc.core import scan_directory
 
 def test_tree_included(tmp_path: Path):
     (tmp_path / "a.py").write_text("pass")
-    files, tree_md = scan_directory(paths=[tmp_path], include_tree=True)
-    assert tree_md is not None
-    assert "a.py" in tree_md
+    files, tree_str = scan_directory(paths=[tmp_path], include_tree=True)
+    assert tree_str is not None
+    assert "a.py" in tree_str

--- a/tests/test_tree_and_formatter.py
+++ b/tests/test_tree_and_formatter.py
@@ -16,8 +16,8 @@ def test_to_tree_nested(tmp_path: Path) -> None:
 
 def test_markdown_formatter_with_tree(tmp_path: Path) -> None:
     (tmp_path / "x.js").write_text("console.log(1)")
-    files, tree_md = scan_directory(paths=[tmp_path], include_tree=True)
-    md = MARKDOWN(files, tree_md)
+    files, tree_str = scan_directory(paths=[tmp_path], include_tree=True)
+    md = MARKDOWN(files, tree_str)
 
     # one code fence pair for the tree and another pair for the file
     assert "**File Structure**\n\n```text" in md.strip()

--- a/tests/test_xml_formatter.py
+++ b/tests/test_xml_formatter.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from scanc.core import scan_directory, ScannedFile
+from scanc.formatter import format_result
+from scanc.cli import main as cli_main
+
+
+def _parse(xml_text: str) -> ET.Element:
+    # Will raise if the output isn't well-formed XML
+    return ET.fromstring(xml_text)
+
+
+def test_xml_formatter_basic_structure_and_languages(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("print('hi')")
+    (tmp_path / "README").write_text("no extension here")
+    # include_tree=True to exercise <tree><![CDATA[...]]></tree>
+    files, tree = scan_directory(paths=[tmp_path], include_tree=True)
+
+    xml_text = format_result(files=files, tree=tree, format_name="xml")
+    root = _parse(xml_text)
+
+    assert root.tag == "scan"
+
+    # tree is optional but should be present because include_tree=True
+    tree_nodes = root.findall("tree")
+    assert len(tree_nodes) == 1
+    assert "a.py" in (tree_nodes[0].text or "")
+
+    # There should be a <file> entry per input file
+    file_nodes = root.findall("file")
+    paths_in_xml = {n.attrib["path"] for n in file_nodes}
+    assert paths_in_xml == {"a.py", "README"}  # relative paths
+
+    # Check code blocks + language attribute mapping
+    by_path = {n.attrib["path"]: n for n in file_nodes}
+    code_a = by_path["a.py"].find("code")
+    code_readme = by_path["README"].find("code")
+    assert code_a is not None and code_readme is not None
+
+    # language is the suffix without dot, or falls back to ScannedFile.language
+    assert code_a.attrib.get("language") == "py"
+    assert code_readme.attrib.get("language") == "text"
+
+    # CDATA should preserve content; ElementTree exposes it as .text
+    assert "print('hi')" in (code_a.text or "")
+    assert "no extension here" in (code_readme.text or "")
+
+
+def test_xml_formatter_escapes_path_and_preserves_special_content(tmp_path: Path) -> None:
+    # Use a path that is safe on all platforms but requires XML escaping (&)
+    weird = tmp_path / "a&b.py"
+    weird.write_text("<tag attr=\"x\">& ' \"</tag>")
+    files, tree = scan_directory(paths=[tmp_path], include_tree=False)
+
+    xml_text = format_result(files=files, tree=tree, format_name="xml")
+    root = _parse(xml_text)
+
+    node = root.find("file")
+    assert node is not None
+    # Attribute should round-trip through XML escaping
+    assert node.attrib["path"].endswith("a&b.py")
+
+    code = node.find("code")
+    assert code is not None
+    # The raw special characters must survive inside CDATA
+    body = (code.text or "")
+    assert "<tag attr=\"x\">& ' \"</tag>" in body
+
+
+def test_xml_formatter_unknown_format_raises(tmp_path: Path) -> None:
+    p = tmp_path / "x.txt"
+    p.write_text("x")
+    files = [ScannedFile(path=p.relative_to(tmp_path), language="text", content="x")]
+
+    with pytest.raises(ValueError):
+        format_result(files=files, tree=None, format_name="not-a-format")
+
+
+def test_cli_emits_valid_xml_with_tree(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text("print(1)")
+    (tmp_path / "n.js").write_text("console.log(2)")
+
+    runner = CliRunner()
+    res = runner.invoke(
+        cli_main,
+        ["--tree", "-f", "xml", str(tmp_path)],
+    )
+
+    assert res.exit_code == 0, res.output
+    root = _parse(res.stdout)
+
+    # sanity checks
+    assert root.tag == "scan"
+    tree_nodes = root.findall("tree")
+    assert len(tree_nodes) == 1
+    txt = tree_nodes[0].text or ""
+    assert "m.py" in txt and "n.js" in txt
+
+    file_nodes = root.findall("file")
+    paths = sorted(n.attrib["path"] for n in file_nodes)
+    assert paths == ["m.py", "n.js"]
+
+    # languages mapped correctly
+    langs = {n.attrib["path"]: n.find("code").attrib.get("language") for n in file_nodes}
+    assert langs == {"m.py": "py", "n.js": "js"}


### PR DESCRIPTION
- `--format, -f` now supports xml parameter for xml output

Code structure:
- Renamed some core functions and adjusted parameters and variables name, because:
- Generating the markdown tree now happens in `formatter.py` to allow for xml specific tree formatting
- Updated tests to resemble structural changes
- Included new test cases for xml and edge cases for xml